### PR TITLE
Add ID to live react component hook wrapper

### DIFF
--- a/lib/phoenix_live_react.ex
+++ b/lib/phoenix_live_react.ex
@@ -75,6 +75,7 @@ defmodule PhoenixLiveReact do
 
     default_attr = [
       style: "display: none;",
+      id: Keyword.get(options, :id),
       data: [
         live_react_class: name,
         live_react_props: Jason.encode!(props),


### PR DESCRIPTION
## Live React Component Wrapper ID

### Description
Passing an id to the `live_react_component` wrapper doesn't mean that the same ID will be applied to the element using the LiveReact Hook call, so Phoenix complains about the LiveReact Hook not having a DOM ID.

### Example
```<%= live_react_component("Components.ShipmentWrapperComponent", %{}, id: "shipment-wrapper-component") %>```

![image](https://user-images.githubusercontent.com/6183702/88231958-6c4fbd00-cc4b-11ea-8dca-adc845399ff0.png)

### Solution
Add an `id` attr using `Keyword.get/3`.

```
default_attr = [
  style: "display: none;",
  id: Keyword.get(options, :id),
  data: [
    live_react_class: name,
    live_react_props: Jason.encode!(props),
    live_react_merge: options[:merge_props] == true
  ],
  "#{binding_prefix}hook": "LiveReact"
]
```
