### PR TITLE
Update README.md instructions for Phoenix 1.7.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ document.addEventListener("DOMContentLoaded", e => {
 })
 ```
 
-Add the helper to your `MyAppWeb` file.
+Add the helper to your `MyAppWeb` file, `lib/MyAppWeb.ex`:
 
 ```elixir
-defp view_helpers do
-  quote do
-    # ...
-    import PhoenixLiveReact
-    # ...
+def live_view do
+    quote do
+      # ...
+      import PhoenixLiveReact
+      # ...
+    end
   end
-end
 ```
 
 Add your react components to the window scope (`app.js`):


### PR DESCRIPTION
Hi!

Phoenix  1.7.10 does not longer have a `view_helpers` function, instead it is called `live_view`.